### PR TITLE
Add skeleton files for `spm_bazel`

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,11 @@
+# For information on the rules, see
+# https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md
+
+--allman false
+--indent 2
+--semicolons never 
+--stripunusedargs always
+--maxwidth 100
+--wraparguments before-first
+--wrapparameters before-first
+--wrapcollections before-first

--- a/Sources/SPMBazel/AsyncParsableCommand.swift
+++ b/Sources/SPMBazel/AsyncParsableCommand.swift
@@ -1,0 +1,25 @@
+import ArgumentParser
+
+// Heavily inspired by
+// https://medium.com/geekculture/develop-a-command-line-tool-using-swift-concurrency-e16d254361cb
+
+// In ArgumentParser 1.1.0 and later, AsyncParsableCommand exists. However, swift-package-manager is
+// pinned to no later than 1.0.3, right now.
+protocol AsyncParsableCommand: ParsableCommand {
+  mutating func runAsync() async throws
+}
+
+public extension ParsableCommand {
+  static func main() async {
+    do {
+      var command = try parseAsRoot(nil)
+      if var asyncCommand = command as? AsyncParsableCommand {
+        try await asyncCommand.runAsync()
+      } else {
+        try command.run()
+      }
+    } catch {
+      exit(withError: error)
+    }
+  }
+}

--- a/Sources/SPMBazel/BUILD.bazel
+++ b/Sources/SPMBazel/BUILD.bazel
@@ -4,7 +4,7 @@ load("//build/swift:swift.bzl", "swift_binary")
 bzlformat_pkg(name = "bzlformat")
 
 swift_binary(
-    name = "SPMBazel",
+    name = "spm_bazel",
     module_name = "SPMBazel",
     visibility = ["//visibility:public"],
     deps = [

--- a/Sources/SPMBazel/BUILD.bazel
+++ b/Sources/SPMBazel/BUILD.bazel
@@ -6,7 +6,7 @@ bzlformat_pkg(name = "bzlformat")
 swift_binary(
     name = "SPMBazel",
     module_name = "SPMBazel",
-    visibility = ["//swift:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = [
         "@apple_swift_argument_parser//:ArgumentParser",
     ],

--- a/Sources/SPMBazel/BUILD.bazel
+++ b/Sources/SPMBazel/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+load("//build/swift:swift.bzl", "swift_binary")
+
+bzlformat_pkg(name = "bzlformat")
+
+swift_binary(
+    name = "SPMBazel",
+    module_name = "SPMBazel",
+    visibility = ["//swift:__subpackages__"],
+    deps = [
+        "@apple_swift_argument_parser//:ArgumentParser",
+    ],
+)

--- a/Sources/SPMBazel/SPMBazel.swift
+++ b/Sources/SPMBazel/SPMBazel.swift
@@ -1,0 +1,58 @@
+import ArgumentParser
+import Foundation
+
+@main
+struct SPMBazel: AsyncParsableCommand {
+  // static let configuration: CommandConfiguration = {
+  //     // if let directory = ProcessInfo.processInfo.environment["BUILD_WORKSPACE_DIRECTORY"] {
+  //     //     FileManager.default.changeCurrentDirectoryPath(directory)
+  //     // }
+
+  //     CommandConfiguration(
+  //         commandName: "spm_bazel",
+  //         abstract: "A tool to manage Swift package dependencies for a Bazel workspace.",
+  //         version: Version.value,
+  //         // subcommands: [
+  //         //     Analyze.self,
+  //         //     Docs.self,
+  //         //     GenerateDocs.self,
+  //         //     Lint.self,
+  //         //     Rules.self,
+  //         //     Version.self
+  //         // ],
+  //         // defaultSubcommand: Lint.self
+  //     )
+  // }()
+
+  mutating func runAsync() async throws {
+    guard let output = "Hello, World!".data(using: .utf8) else {
+      return
+    }
+    try writeOutput { fileHandle in
+      try fileHandle.write(contentsOf: output)
+    }
+  }
+
+  private func createFileHandle() throws -> FileHandle {
+    return .standardOutput
+    // guard let outputFile = outputFile else {
+    //     return .standardOutput
+    // }
+    // // Create the file, then create the file handle
+    // guard FileManager.default.createFile(atPath: outputFile.path, contents: nil) else {
+    //     throw DumpError.failedToCreateOutputFile(outputFile.path)
+    // }
+    // guard let outputFileHandle = FileHandle(forWritingAtPath: outputFile.path) else {
+    //     throw DumpError.failedToOpenOutputFile(outputFile.path)
+    // }
+    // return outputFileHandle
+  }
+
+  func writeOutput(closure: (_ fileHandle: FileHandle) throws -> Void) throws {
+    let fileHandle = try createFileHandle()
+    defer {
+      try? fileHandle.close()
+    }
+    try closure(fileHandle)
+  }
+}

--- a/Sources/SPMBazel/SPMBazel.swift
+++ b/Sources/SPMBazel/SPMBazel.swift
@@ -3,27 +3,6 @@ import Foundation
 
 @main
 struct SPMBazel: AsyncParsableCommand {
-  // static let configuration: CommandConfiguration = {
-  //     // if let directory = ProcessInfo.processInfo.environment["BUILD_WORKSPACE_DIRECTORY"] {
-  //     //     FileManager.default.changeCurrentDirectoryPath(directory)
-  //     // }
-
-  //     CommandConfiguration(
-  //         commandName: "spm_bazel",
-  //         abstract: "A tool to manage Swift package dependencies for a Bazel workspace.",
-  //         version: Version.value,
-  //         // subcommands: [
-  //         //     Analyze.self,
-  //         //     Docs.self,
-  //         //     GenerateDocs.self,
-  //         //     Lint.self,
-  //         //     Rules.self,
-  //         //     Version.self
-  //         // ],
-  //         // defaultSubcommand: Lint.self
-  //     )
-  // }()
-
   mutating func runAsync() async throws {
     guard let output = "Hello, World!".data(using: .utf8) else {
       return
@@ -35,17 +14,6 @@ struct SPMBazel: AsyncParsableCommand {
 
   private func createFileHandle() throws -> FileHandle {
     return .standardOutput
-    // guard let outputFile = outputFile else {
-    //     return .standardOutput
-    // }
-    // // Create the file, then create the file handle
-    // guard FileManager.default.createFile(atPath: outputFile.path, contents: nil) else {
-    //     throw DumpError.failedToCreateOutputFile(outputFile.path)
-    // }
-    // guard let outputFileHandle = FileHandle(forWritingAtPath: outputFile.path) else {
-    //     throw DumpError.failedToOpenOutputFile(outputFile.path)
-    // }
-    // return outputFileHandle
   }
 
   func writeOutput(closure: (_ fileHandle: FileHandle) throws -> Void) throws {

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -1,0 +1,3 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")

--- a/build/swift/BUILD.bazel
+++ b/build/swift/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+bzl_library(
+    name = "swift",
+    srcs = ["swift.bzl"],
+)

--- a/build/swift/swift.bzl
+++ b/build/swift/swift.bzl
@@ -1,0 +1,38 @@
+"""Macros to combine swift_XXX rules and swiftformat."""
+
+load(
+    "@cgrindel_rules_swiftformat//swiftformat:swiftformat.bzl",
+    "swiftformat_binary",
+    "swiftformat_library",
+    "swiftformat_test",
+)
+
+def swift_binary(name, srcs = None, **kwargs):
+    if srcs == None:
+        srcs = native.glob(["**/*.swift"])
+
+    swiftformat_binary(
+        name = name,
+        srcs = srcs,
+        **kwargs
+    )
+
+def swift_library(name, srcs = None, **kwargs):
+    if srcs == None:
+        srcs = native.glob(["*.swift"])
+
+    swiftformat_library(
+        name = name,
+        srcs = srcs,
+        **kwargs
+    )
+
+def swift_test(name, srcs = None, **kwargs):
+    if srcs == None:
+        srcs = native.glob(["*.swift"])
+
+    swiftformat_test(
+        name = name,
+        srcs = srcs,
+        **kwargs
+    )

--- a/deps.bzl
+++ b/deps.bzl
@@ -1,7 +1,10 @@
+"""Dependencies for spm_bazel"""
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def spm_bazel_dependencies():
+    """Defines the dependencies for spm_bazel."""
     maybe(
         http_archive,
         name = "build_bazel_rules_swift",
@@ -42,3 +45,60 @@ def spm_bazel_dependencies():
             "http://github.com/bazelbuild/rules_cc/archive/cb6d32e4d1ae29e20dd3328109d8cb7f8eccc9be.tar.gz",
         ],
     )
+
+    maybe(
+        http_archive,
+        name = "apple_swift_argument_parser",
+        strip_prefix = "swift-argument-parser-1.0.3",
+        urls = ["https://github.com/apple/swift-argument-parser/archive/1.0.3.tar.gz"],
+        sha256 = "a4d4c08cf280615fe6e00752ef60e28e76f07c25eb4706a9269bf38135cd9c3f",
+        build_file_content = """
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library")
+
+swift_library(
+    name = "ArgumentParserToolInfo",
+    srcs = glob(["Sources/ArgumentParserToolInfo/**/*.swift"]),
+    module_name = "ArgumentParserToolInfo",
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "ArgumentParser",
+    srcs = glob(["Sources/ArgumentParser/**/*.swift"]),
+    module_name = "ArgumentParser",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":ArgumentParserToolInfo",
+    ]
+)
+""",
+    )
+
+    # maybe(
+    #     github_source_archive,
+    #     name = "apple_swift_argument_parser",
+    #     repo = "apple/swift-argument-parser",
+    #     version = "1.0.3",
+    #     sha256 = "a4d4c08cf280615fe6e00752ef60e28e76f07c25eb4706a9269bf38135cd9c3f",
+    #     build_file_content = """
+
+# load("//build/swift:swift_library.bzl", "swift_library")
+
+# swift_library(
+# name = "ArgumentParserToolInfo",
+# srcs = glob("Sources/ArgumentParserToolInfo/**/*.swift"),
+# module_name = "ArgumentParserToolInfo",
+# visibility = ["//visibility:public"],
+# )
+
+# swift_library(
+# name = "ArgumentParser",
+# srcs = glob("Sources/ArgumentParserToolInfo/**/*.swift"),
+# module_name = "ArgumentParser",
+# visibility = ["//visibility:public"],
+# deps = [
+#     ":ArgumentParserToolInfo",
+# ]
+# )
+# """,
+# )

--- a/deps.bzl
+++ b/deps.bzl
@@ -73,32 +73,3 @@ swift_library(
 )
 """,
     )
-
-    # maybe(
-    #     github_source_archive,
-    #     name = "apple_swift_argument_parser",
-    #     repo = "apple/swift-argument-parser",
-    #     version = "1.0.3",
-    #     sha256 = "a4d4c08cf280615fe6e00752ef60e28e76f07c25eb4706a9269bf38135cd9c3f",
-    #     build_file_content = """
-
-# load("//build/swift:swift_library.bzl", "swift_library")
-
-# swift_library(
-# name = "ArgumentParserToolInfo",
-# srcs = glob("Sources/ArgumentParserToolInfo/**/*.swift"),
-# module_name = "ArgumentParserToolInfo",
-# visibility = ["//visibility:public"],
-# )
-
-# swift_library(
-# name = "ArgumentParser",
-# srcs = glob("Sources/ArgumentParserToolInfo/**/*.swift"),
-# module_name = "ArgumentParser",
-# visibility = ["//visibility:public"],
-# deps = [
-#     ":ArgumentParserToolInfo",
-# ]
-# )
-# """,
-# )

--- a/integration_tests/BUILD.bazel
+++ b/integration_tests/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@cgrindel_bazel_starlib//bzlformat:defs.bzl", "bzlformat_pkg")
+
+bzlformat_pkg(name = "bzlformat")
+
+sh_test(
+    name = "no_cmd_test",
+    srcs = ["no_cmd_test.sh"],
+    data = ["//Sources/SPMBazel"],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+        "@cgrindel_bazel_starlib//shlib/lib:assertions",
+    ],
+)

--- a/integration_tests/BUILD.bazel
+++ b/integration_tests/BUILD.bazel
@@ -5,7 +5,7 @@ bzlformat_pkg(name = "bzlformat")
 sh_test(
     name = "no_cmd_test",
     srcs = ["no_cmd_test.sh"],
-    data = ["//Sources/SPMBazel"],
+    data = ["//Sources/SPMBazel:spm_bazel"],
     deps = [
         "@bazel_tools//tools/bash/runfiles",
         "@cgrindel_bazel_starlib//shlib/lib:assertions",

--- a/integration_tests/no_cmd_test.sh
+++ b/integration_tests/no_cmd_test.sh
@@ -22,7 +22,7 @@ source "${assertions_sh}"
 
 # Variables
 
-spm_bazel_location=cgrindel_spm_bazel/Sources/SPMBazel/SPMBazel
+spm_bazel_location=cgrindel_spm_bazel/Sources/SPMBazel/spm_bazel
 spm_bazel="$(rlocation "${spm_bazel_location}")" || \
   (echo >&2 "Failed to locate ${spm_bazel_location}" && exit 1)
 

--- a/integration_tests/no_cmd_test.sh
+++ b/integration_tests/no_cmd_test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+# shellcheck disable=SC1090
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 ---
+
+# Locate Deps
+
+assertions_sh_location=cgrindel_bazel_starlib/shlib/lib/assertions.sh
+assertions_sh="$(rlocation "${assertions_sh_location}")" || \
+  (echo >&2 "Failed to locate ${assertions_sh_location}" && exit 1)
+# shellcheck disable=SC1090
+source "${assertions_sh}"
+
+# Variables
+
+spm_bazel_location=cgrindel_spm_bazel/Sources/SPMBazel/SPMBazel
+spm_bazel="$(rlocation "${spm_bazel_location}")" || \
+  (echo >&2 "Failed to locate ${spm_bazel_location}" && exit 1)
+
+# Tests
+
+# Ensure that the help text is rendered
+output="$($spm_bazel)"
+assert_match "Hello, World!" "${output}"

--- a/swiftformat
+++ b/swiftformat
@@ -1,0 +1,11 @@
+#!/usr/bin/env zsh
+
+# This file exists to support formatting in vim using vim-ale.
+# This script ensures that the config file is used when formatting.
+
+set -euo pipefail
+
+script_dir="${0:A:h}"
+config_file="${script_dir}/.swiftformat"
+
+swiftformat --config "${config_file}" "${@}"


### PR DESCRIPTION
- Add `swiftformat` script and `.swiftformat` config file.
- Add `swift_XXX` macros to combine swift_XXX rules and swiftformat rules.
- Add `SPMBazel` root command